### PR TITLE
Feature/mock aws

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -54,9 +54,9 @@ jobs:
           docker push "${{ matrix.GHCR_CACHED_TAG_PREFIX }}-${TARGET_BASE}"
           docker push "${{ matrix.GHCR_CACHED_TAG_PREFIX }}-${TARGET_APP}"
 
-  dockerhub-push:
+  testing:
     needs: docker-build
-    name: push latest
+    name: testing
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,4 @@
-name: Push latest version to DockerHub
+name: Testing
 
 on:
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ARG APP_USER_ID="1000"
 ARG APP_GROUP_NAME="appgroup"
 ARG APP_GROUP_ID="1000"
 
-RUN apk add --no-cache bash jq libstdc++ util-linux
+RUN apk add --no-cache bash jq libstdc++ util-linux git
 COPY --from=download /downloads/terraform /usr/local/bin/terraform
 COPY --from=download /downloads/hcl2json /usr/local/bin/hcl2json
 COPY --from=build-fswatch /usr/local/lib/*.so /usr/local/lib/*.so.* /usr/local/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=download /downloads/terraform /usr/local/bin/terraform
 COPY --from=download /downloads/hcl2json /usr/local/bin/hcl2json
 COPY --from=build-fswatch /usr/local/lib/*.so /usr/local/lib/*.so.* /usr/local/lib/
 COPY --from=build-fswatch /usr/local/bin/fswatch /usr/local/bin/fswatch
-WORKDIR /code/
+WORKDIR /src/
 RUN \
     addgroup -g "${APP_GROUP_ID}" "${APP_GROUP_NAME}" && \
     adduser -H -D -u "$APP_USER_ID" -G "$APP_GROUP_NAME" "$APP_USER_NAME" && \

--- a/README.md
+++ b/README.md
@@ -142,6 +142,27 @@ tfcoding    | }
 
 </details>
 
+### Mock AWS
+
+This feature relies on the open-source project [localstack](https://github.com/localstack/localstack), which means you can provision the [AWS core resources](https://github.com/localstack/localstack#overview), see [examples/mock-aws/](./examples/mock-aws/)
+
+#### IMPORTANT
+
+You might encounter the below warning after executing `docker-compose up` - **DO NOT** add the `--remove-orphans` flag
+
+> *WARNING: Found orphan containers (tfcoding, localstack) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.*
+
+Let's go!
+
+```bash
+$ git clone https://github.com/unfor19/tfcoding.git
+$ cd tfcoding
+$ docker-compose -p tfcoding -f docker-compose-localstack.yml up --detached
+$ docker-compose -p tfcoding -f docker-compose-aws.yml up
+...
+# Change something in examples/mock-aws/tfcoding.tf
+```
+
 ## Authors
 
 Created and maintained by [Meir Gabay](https://github.com/unfor19)

--- a/bargs_vars
+++ b/bargs_vars
@@ -29,6 +29,12 @@ description=Auto-render tfcoding.tf on change
 flag=true
 default=false
 ---
+name=mock_aws
+short=aws
+description=Use this flag for communicating with Localstack
+flag=true
+default=false
+---
 name=bargs
 short=bargs
 description=bash entrypoint.sh -r basic/exmaples --watching -o private_subnets

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -4,19 +4,21 @@ networks:
   shared:
 
 volumes:
-  code_dir_tmp:
+  code_dir_tmp_aws:
 
 services:
-  tfcoding:
-    container_name: tfcoding
+  tfcoding-aws:
+    container_name: tfcoding-aws
     image: unfor19/tfcoding:latest
     volumes:
       - ./:/src/:ro
-      - code_dir_tmp:/tmp/
+      - code_dir_tmp_aws:/tmp/
+
     command:
       - "--src_dir_relative_path"
-      - "${SRC_DIR_RELATIVE_PATH:-examples/basic}"
+      - "${SRC_DIR_RELATIVE_PATH:-examples/mock-aws}"
       - "--watching"
+      - "--mock_aws"
     restart: always
     tty: true # colorful output
     networks:

--- a/docker-compose-localstack.yml
+++ b/docker-compose-localstack.yml
@@ -1,0 +1,27 @@
+version: "3.7"
+
+networks:
+  shared:
+
+services:
+  localstack:
+    container_name: localstack
+    image: localstack/localstack:0.12.8
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+      - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
+    environment:
+      - SERVICES=${SERVICES- }
+      - DEBUG=${DEBUG- }
+      - DATA_DIR=${DATA_DIR- }
+      - PORT_WEB_UI=${PORT_WEB_UI-8080}
+      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
+      - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - HOST_TMP_FOLDER=${TMPDIR}
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    networks:
+      - shared

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,43 @@
 version: "3.7"
 
+networks:
+  net1:
+
 services:
   tfcoding:
+    depends_on:
+      - localstack
     container_name: tfcoding
     image: unfor19/tfcoding:latest
     volumes:
       - ./:/src/:ro
     command:
       - "--src_dir_relative_path"
-      - "${SRC_DIR_RELATIVE_PATH:-examples/basic}"
+      - "${SRC_DIR_RELATIVE_PATH:-examples/mock-aws}"
       - "--watching"
     restart: always
     tty: true # colorful output
+    networks:
+      - net1
+
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: localstack/localstack
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+      - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
+    environment:
+      - SERVICES=${SERVICES- }
+      - DEBUG=${DEBUG- }
+      - DATA_DIR=${DATA_DIR- }
+      - PORT_WEB_UI=${PORT_WEB_UI- }
+      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
+      - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - HOST_TMP_FOLDER=${TMPDIR}
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    networks:
+      - net1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,9 +7,6 @@ set -e
 set -o pipefail
 
 # Global variables
-export TF_PLUGIN_CACHE_DIR="/code/.terraform.d/plugin-cache"
-mkdir -p "$TF_PLUGIN_CACHE_DIR"
-
 [[ "$SINGLE_VALUE_OUTPUT" = "all" ]] && SINGLE_VALUE_OUTPUT=""
 _SINGLE_VALUE_OUTPUT="${SINGLE_VALUE_OUTPUT:-""}"
 
@@ -18,12 +15,28 @@ _SRC_DIR_RELATIVE_PATH="$SRC_DIR_RELATIVE_PATH"
 [[ -z "$_SRC_DIR_RELATIVE_PATH" ]] && error_msg "Relative path is required, create a directory that contains tfcoding.tf"
 _SRC_DIR_ABSOLUTE_PATH="${_SRC_DIR_ROOT}/${_SRC_DIR_RELATIVE_PATH}"
 _CODE_FILE_NAME="tfcoding.tf"
-_CODE_DIR_SRC="/code/src"
+_CODE_DIR_TMP="/tmp"
 _SRC_FILE_ABSOLUTE_PATH="${_SRC_DIR_ABSOLUTE_PATH}/${_CODE_FILE_NAME}"
 
+
+# Terraform Plugins (providers) cache dir
+export TF_PLUGIN_CACHE_DIR="${_CODE_DIR_TMP}/.terraform.d/plugin-cache"
+[[ ! -d "$TF_PLUGIN_CACHE_DIR" ]] && mkdir -p "$TF_PLUGIN_CACHE_DIR"
+
+
+# Terraform Modules cache dir
+export TF_DATA_DIR="${_CODE_DIR_TMP}/.terraform"
+[[ ! -d "$_CODE_DIR_TMP" ]] && mkdir -p "$_CODE_DIR_TMP"
+
+
+# Flags and boolean args
 _LOGGING="${LOGGING:-"true"}"
 _DEBUG="${DEBUG:-"false"}"
 _WATCHING="${WATCHING:-"false"}"
+_MOCK_AWS="${MOCK_AWS:-"false"}"
+
+
+_TMP_DIR_TF_FILES="${_CODE_DIR_TMP}/code"
 
 # Functions
 error_msg(){
@@ -57,31 +70,32 @@ validation(){
 
 
 copy_files(){
-  # Copy relevant files from /src/ to /code/ dir
-  rm -rf "$_CODE_DIR_SRC"
-  mkdir -p "$_CODE_DIR_SRC"
+  [[ -f "${_TMP_DIR_TF_FILES}/terraform.tfstate" ]] && mv "${_TMP_DIR_TF_FILES}/terraform.tfstate" "${_CODE_DIR_TMP}/terraform.tfstate"
+  rm -rf "${_TMP_DIR_TF_FILES}"
+  mkdir -p "${_TMP_DIR_TF_FILES}"
   find "$_SRC_DIR_ABSOLUTE_PATH" -type f \( -name '*.tf' -o -name '*.tpl' -o -name '*.json' \) \
-    -and \( -not -path '.git/' -not -path '.terraform/' -and -not -path ''"$_CODE_DIR_SRC"'*' \) -exec cp {} "$_CODE_DIR_SRC" \;
-  
-  if [[ ! -f "$_CODE_DIR_SRC/$_CODE_FILE_NAME" ]]; then
-    error_msg "File does not exist - $_CODE_DIR_SRC/$_CODE_FILE_NAME"
-  fi
+    -and \( -not -path '.git/' -not -path '.terraform/' \) -exec cp {} "$_TMP_DIR_TF_FILES" \;
+  [[ -f "${_CODE_DIR_TMP}/terraform.tfstate" ]] && cp "${_CODE_DIR_TMP}/terraform.tfstate" "${_TMP_DIR_TF_FILES}/terraform.tfstate"
+  wait # prevents sudden exit
 }
 
 
 terraform_init(){
   # Create a local empty tfstate file
-  cd "$_CODE_DIR_SRC"
-  terraform init # 1>/dev/null
+  cd "$_TMP_DIR_TF_FILES"
+  if [[ "$_MOCK_AWS" = "true" ]]; then
+    terraform init
+  else
+    terraform init 1>/dev/null
+  fi
 }
 
 
 inject_outputs(){
   # Inject outputs to $_CODE_FILE_NAME according to locals{}
-  cd "$_CODE_DIR_SRC"
-  declare -a arr=($(hcl2json "$_CODE_FILE_NAME" | jq -r '.locals[] | keys[]'))
+  declare -a arr=($(hcl2json "${_TMP_DIR_TF_FILES}/${_CODE_FILE_NAME}" | jq -r '.locals[] | keys[]'))
   for local_value in "${arr[@]}"; do
-      cat <<EOF >> "$_CODE_FILE_NAME"
+      cat <<EOF >> "${_TMP_DIR_TF_FILES}/${_CODE_FILE_NAME}"
 
 
 output "${local_value}" {
@@ -91,37 +105,59 @@ output "${local_value}" {
 
 EOF
   done
+
 }
 
 
 debug_mode(){
-  cd "$_CODE_DIR_SRC"
   if [[ $_DEBUG = "true" ]]; then
-    cat "$_CODE_FILE_NAME"
+    cat "$_TMP_DIR_TF_FILES/$_CODE_FILE_NAME"
   fi
 }
 
 
 render_tfcoding(){
   # terraform apply renders the outputs
-  cd "$_CODE_DIR_SRC"
+  cd "$_TMP_DIR_TF_FILES"
   terraform fmt 1>/dev/null
-  terraform validate 1>/dev/null
-  terraform apply -auto-approve # 1>/dev/null
-  if [[ -n $_SINGLE_VALUE_OUTPUT ]]; then
-    # single output
-    local output_msg
-    output_msg="$(terraform output -json "${_SINGLE_VALUE_OUTPUT}" 2>&1 || true)"
-    if [[ "$output_msg" =~ .*output.*not.*found ]]; then
-      error_msg "Local Value not defined: ${_SINGLE_VALUE_OUTPUT}"
-    else
-      echo "{\"${_SINGLE_VALUE_OUTPUT}\":${output_msg}}" | jq
-    fi
-  else
-    # all outputs (local values)
-    terraform output -json | jq 'map_values(.value)'
+
+  if ! terraform validate 1>/dev/null ; then
+    log_msg "Fix the above syntax error"
+    return
   fi
-  
+
+  if [[ "$_MOCK_AWS" = "true" ]]; then
+    # Mock AWS
+    if terraform plan -input=false -out=plan.tfout -compact-warnings ; then
+      if ! terraform apply -lock=false -auto-approve -compact-warnings plan.tfout ; then
+        log_msg "terraform apply - Fix the above error"
+        return
+      fi
+    else
+      log_msg "terraform plan - Fix the above error"
+      return
+    fi
+  elif [[ "$_MOCK_AWS" != "true" ]]; then  
+    # Local Values only
+    if ! terraform apply -lock=false -input=false -auto-approve -compact-warnings 1>/dev/null ; then
+      log_msg "terraform apply - Fix the above error"
+      return
+    fi
+
+    if [[ -n $_SINGLE_VALUE_OUTPUT ]]; then
+      # Single Local Value Output
+      local output_msg
+      output_msg="$(terraform output -json "${_SINGLE_VALUE_OUTPUT}" 2>&1 || true)"
+      if [[ "$output_msg" =~ .*output.*not.*found ]]; then
+        error_msg "Local Value not defined: ${_SINGLE_VALUE_OUTPUT}"
+      else
+        echo "{\"${_SINGLE_VALUE_OUTPUT}\":${output_msg}}" | jq
+      fi
+    else
+      # All Outputs (Local Values)
+      terraform output -json | jq 'map_values(.value)'
+    fi
+  fi
 }
 
 
@@ -133,14 +169,14 @@ main(){
   inject_outputs
   debug_mode
   render_tfcoding
+  [[ "$_LOGGING" = "true" && "$_WATCHING" = "true" ]] && log_msg "Watching for changes in ${_SRC_FILE_ABSOLUTE_PATH}"
 }
 
 [[ "$_LOGGING" = "true" ]] && log_msg "$(terraform version)"
-if [[ "$_WATCHING" = "true" ]] ; then
+if [[ "$_WATCHING" = "true" ]]; then
   # Execute on file change in code file - tfcoding.tf
   log_msg "Rendered for the first time"
   main
-  [[ "$_LOGGING" = "true" ]] && log_msg "Watching for changes in ${_SRC_FILE_ABSOLUTE_PATH}"
   fswatch -0 -m poll_monitor --batch-marker --event-flags "${_SRC_DIR_ABSOLUTE_PATH}/${_CODE_FILE_NAME}" | while read -r -d "" event; do
     if [[ "$event" = "NoOp" ]]; then
       [[ "$_LOGGING" = "true" ]] && log_msg "Rendered"

--- a/examples/basic/tfcoding.tf
+++ b/examples/basic/tfcoding.tf
@@ -5,14 +5,14 @@ variable "environment" {
 variable "cidr_ab" {
   type = map(string)
   default = {
-    "dev": "10.10"
-    "stg": "10.11"
-    "prd": "10.12"
+    "dev" : "10.10"
+    "stg" : "10.11"
+    "prd" : "10.12"
   }
 }
 
 locals {
-  cidr_ab = "${lookup(var.cidr_ab, var.environment)}"
+  cidr_ab = lookup(var.cidr_ab, var.environment)
   private_subnets = [
     "${local.cidr_ab}.0.0/24",
     "${local.cidr_ab}.1.0/24",

--- a/examples/mock-aws/provider.tf
+++ b/examples/mock-aws/provider.tf
@@ -1,0 +1,36 @@
+variable "region" {
+  default = "us-east-1"
+}
+
+provider "aws" {
+  access_key                  = "mock_access_key"
+  region                      = "us-east-1"
+  s3_force_path_style         = true
+  secret_key                  = "mock_secret_key"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    apigateway     = "http://localstack:4566"
+    cloudformation = "http://localstack:4566"
+    cloudwatch     = "http://localstack:4566"
+    dynamodb       = "http://localstack:4566"
+    ec2            = "http://localstack:4566"
+    es             = "http://localstack:4566"
+    firehose       = "http://localstack:4566"
+    iam            = "http://localstack:4566"
+    kinesis        = "http://localstack:4566"
+    lambda         = "http://localstack:4566"
+    route53        = "http://localstack:4566"
+    redshift       = "http://localstack:4566"
+    s3             = "http://localstack:4566"
+    secretsmanager = "http://localstack:4566"
+    ses            = "http://localstack:4566"
+    sns            = "http://localstack:4566"
+    sqs            = "http://localstack:4566"
+    ssm            = "http://localstack:4566"
+    stepfunctions  = "http://localstack:4566"
+    sts            = "http://localstack:4566"
+  }
+}

--- a/examples/mock-aws/tfcoding.tf
+++ b/examples/mock-aws/tfcoding.tf
@@ -1,0 +1,23 @@
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["us-east-1a", "us-east-1b"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24"]
+
+  enable_nat_gateway = false
+  enable_vpn_gateway = false
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
+}
+
+locals {
+  my_value  = module.vpc.vpc_id
+  my_subnet = module.vpc.public_subnets
+}


### PR DESCRIPTION
- Added [localstack](https://github.com/localstack/localstack) to mock [AWS core services](https://github.com/localstack/localstack#overview)
- Added docker-compose for using mock-aws - `provider.tf` is a crucial part of the code. The region must be set to `eu-east-1`, and just an FYI data_sources are not available, so don't try to query for the EC2 AMIs
- The state file `terraform.tfstate` is preserved, even when doing `docker-compose down`
- TODO: Add an option to remove `terraform.tfstate`