### PR TITLE
added support for arm64 and upgraded localstack and terraform versions

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -19,36 +19,30 @@ jobs:
       matrix:
         include:
           - DOCKERFILE_PATH: Dockerfile
-            TERRAFORM_VERSION: "0.13.6"
+            TERRAFORM_VERSION: "1.5.5"
           - DOCKERFILE_PATH: Dockerfile
-            TERRAFORM_VERSION: "0.14.8"
-          - DOCKERFILE_PATH: Dockerfile
-            TERRAFORM_VERSION: "0.15.0-beta2"
-          - DOCKERFILE_PATH: Dockerfile
-            TERRAFORM_VERSION: "1.0.6"
-          - DOCKERFILE_PATH: Dockerfile
-            TERRAFORM_VERSION: "1.2.9"
+            TERRAFORM_VERSION: "1.6.6"
     env:
       DOCKERFILE_PATH: ${{ matrix.DOCKERFILE_PATH }}
       TERRAFORM_VERSION: ${{ matrix.TERRAFORM_VERSION }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3.0.0
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Docker Build
-        uses: docker/build-push-action@v3
+      - name: Docker Build linux/amd64 for Tests
+        uses: docker/build-push-action@v5.1.0
         with:
-          file: ${{ env.DOCKERFILE_PATH }}
-          context: ${{ env.DOCKER_WORKDIR }}
+          file: Dockerfile
+          context: .
           push: false
           platforms: linux/amd64
           target: app
@@ -62,11 +56,11 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Test
         run: make test
-      - name: Docker Build amd64 and load
+      - name: Docker Build arm64 and push both arm64 and amd64
         uses: docker/build-push-action@v3
         with:
-          file: ${{ env.DOCKERFILE_PATH }}
-          context: ${{ env.DOCKER_WORKDIR }}
+          file: Dockerfile
+          context: .
           push: true
           platforms: linux/amd64,linux/arm64
           target: app
@@ -75,23 +69,6 @@ jobs:
           tags: |
             ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.GITHUB_REF_SLUG }}
             ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.GITHUB_SHA_SHORT }}
-          load: false # Must be false to push linux/arm64 images
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Docker Build arm64 and Push
-        if: ${{ env.GITHUB_REF_SLUG == 'master' }}
-        uses: docker/build-push-action@v3
-        with:
-          file: ${{ env.DOCKERFILE_PATH }}
-          context: ${{ env.DOCKER_WORKDIR }}
-          push: true
-          platforms: linux/amd64,linux/arm64
-          target: app
-          build-args: |
-            TERRAFORM_VERSION=${{ env.TERRAFORM_VERSION }}
-          tags: |
-            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-latest
-            ${{ env.DOCKERHUB_REPOSITORY }}:latest
           load: false # Must be false to push linux/arm64 images
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Docker Build linux/amd64 for Tests
+      - name: Build - amd64 for running Test
         uses: docker/build-push-action@v5.1.0
         with:
           file: Dockerfile
@@ -60,7 +60,7 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Test
         run: make test
-      - name: Side Branch - Docker Build arm64 and push both arm64 and amd64
+      - name: Side Branch - Build - arm64, Push - arm64,amd64
         if: env.GIT_REF_SLUG != 'master'
         uses: docker/build-push-action@v5.1.0
         with:
@@ -77,7 +77,7 @@ jobs:
           load: false # Must be false to push linux/arm64 images
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Latest - Docker Build arm64 and push both arm64 and amd64
+      - name: Latest master - Build - arm64, Push - arm64,amd64
         if: env.GIT_REF_SLUG == 'master'
         uses: docker/build-push-action@v5.1.0
         with:
@@ -94,7 +94,7 @@ jobs:
           load: false # Must be false to push linux/arm64 images
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Latest - Docker Build arm64 and push both arm64 and amd64
+      - name: Latest Tag - Build - arm64, Push - arm64,amd64
         if: env.GIT_REF_SLUG == 'master' && env.TERRAFORM_VERSION == '1.6.6'
         uses: docker/build-push-action@v5.1.0
         with:
@@ -107,6 +107,7 @@ jobs:
             TERRAFORM_VERSION=${{ env.TERRAFORM_VERSION }}
           tags: |
             ${{ env.DOCKERHUB_REPOSITORY }}:latest
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}
             ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.TERRAFORM_VERSION }}
           load: false # Must be false to push linux/arm64 images
           cache-from: type=gha

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -72,8 +72,8 @@ jobs:
           build-args: |
             TERRAFORM_VERSION=${{ env.TERRAFORM_VERSION }}
           tags: |
-            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.GITHUB_REF_SLUG }}
-            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.GITHUB_SHA_SHORT }}
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.TERRAFORM_VERSION }}-${{ env.GITHUB_REF_SLUG }}
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.TERRAFORM_VERSION }}-${{ env.GITHUB_SHA_SHORT }}
           load: false # Must be false to push linux/arm64 images
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -90,7 +90,7 @@ jobs:
             TERRAFORM_VERSION=${{ env.TERRAFORM_VERSION }}
           tags: |
             ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.TERRAFORM_VERSION }}
-            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.GITHUB_SHA_SHORT }}
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.TERRAFORM_VERSION }}-${{ env.GITHUB_SHA_SHORT }}
           load: false # Must be false to push linux/arm64 images
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -60,8 +60,9 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Test
         run: make test
-      - name: Docker Build arm64 and push both arm64 and amd64
-        uses: docker/build-push-action@v3
+      - name: Side Branch - Docker Build arm64 and push both arm64 and amd64
+        if: env.GIT_REF_SLUG != 'master'
+        uses: docker/build-push-action@v5.1.0
         with:
           file: Dockerfile
           context: .
@@ -73,6 +74,40 @@ jobs:
           tags: |
             ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.GITHUB_REF_SLUG }}
             ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.GITHUB_SHA_SHORT }}
+          load: false # Must be false to push linux/arm64 images
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Latest - Docker Build arm64 and push both arm64 and amd64
+        if: env.GIT_REF_SLUG == 'master'
+        uses: docker/build-push-action@v5.1.0
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          target: app
+          build-args: |
+            TERRAFORM_VERSION=${{ env.TERRAFORM_VERSION }}
+          tags: |
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.TERRAFORM_VERSION }}
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.GITHUB_SHA_SHORT }}
+          load: false # Must be false to push linux/arm64 images
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Latest - Docker Build arm64 and push both arm64 and amd64
+        if: env.GIT_REF_SLUG == 'master' && env.TERRAFORM_VERSION == '1.6.6'
+        uses: docker/build-push-action@v5.1.0
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          target: app
+          build-args: |
+            TERRAFORM_VERSION=${{ env.TERRAFORM_VERSION }}
+          tags: |
+            ${{ env.DOCKERHUB_REPOSITORY }}:latest
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TFCODING_VERSION }}-${{ env.TERRAFORM_VERSION }}
           load: false # Must be false to push linux/arm64 images
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.4.1
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.0.0
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -19,9 +19,13 @@ jobs:
       matrix:
         include:
           - DOCKERFILE_PATH: Dockerfile
+            TERRAFORM_VERSION: "1.4.6"
+          - DOCKERFILE_PATH: Dockerfile
             TERRAFORM_VERSION: "1.5.5"
           - DOCKERFILE_PATH: Dockerfile
             TERRAFORM_VERSION: "1.6.6"
+          - DOCKERFILE_PATH: Dockerfile
+            TERRAFORM_VERSION: "1.7.0-rc1"
     env:
       DOCKERFILE_PATH: ${{ matrix.DOCKERFILE_PATH }}
       TERRAFORM_VERSION: ${{ matrix.TERRAFORM_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 ARG PYTHON_VERSION="3.9.18"
-ARG OS_ARCH="amd64"
 ARG ALPINE_VERSION="3.19"
 ARG TERRAFORM_VERSION="1.6.6"
 ARG HCL2JSON_VERSION="v0.6.0"
@@ -13,15 +12,16 @@ FROM alpine:${ALPINE_VERSION} as download
 ARG TERRAFORM_VERSION
 ARG HCL2JSON_VERSION
 ARG FSWATCH_VERSION
-ARG OS_ARCH
 
+ENV OS_ARCH="amd64"
 WORKDIR /downloads/
-RUN apk add --no-cache unzip curl
-RUN curl -sL -o terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${OS_ARCH}.zip"
-RUN unzip terraform.zip && rm terraform.zip
-RUN curl -sL -o hcl2json "https://github.com/tmccombs/hcl2json/releases/download/${HCL2JSON_VERSION}/hcl2json_linux_${OS_ARCH}" && chmod +x hcl2json
-RUN curl -sL -o fswatch.tar.gz "https://github.com/emcrisostomo/fswatch/releases/download/${FSWATCH_VERSION}/fswatch-${FSWATCH_VERSION}.tar.gz"
-RUN tar -xzf fswatch.tar.gz && mv "fswatch-${FSWATCH_VERSION}" fswatch && rm fswatch.tar.gz
+RUN if "$(uname -m)" = "aarch64" ; then export OS_ARCH=arm64; fi && \
+    apk add --no-cache unzip curl && \
+    curl -sL -o terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${OS_ARCH}.zip" && \
+    unzip terraform.zip && rm terraform.zip && \
+    curl -sL -o hcl2json "https://github.com/tmccombs/hcl2json/releases/download/${HCL2JSON_VERSION}/hcl2json_linux_${OS_ARCH}" && chmod +x hcl2json && \
+    curl -sL -o fswatch.tar.gz "https://github.com/emcrisostomo/fswatch/releases/download/${FSWATCH_VERSION}/fswatch-${FSWATCH_VERSION}.tar.gz" && \
+    tar -xzf fswatch.tar.gz && mv "fswatch-${FSWATCH_VERSION}" fswatch && rm fswatch.tar.gz
 # Output: /downloads/ terraform, hcl2json, fswatch
 
 
@@ -30,8 +30,7 @@ RUN apk add --no-cache file git autoconf automake libtool make g++ texinfo curl
 ENV ROOT_HOME /root
 WORKDIR ${ROOT_HOME}
 COPY --from=download /downloads/fswatch .
-RUN ./configure && make -j
-RUN make install
+RUN ./configure && make -j && make install
 # Output: /usr/local/bin/fswatch, /usr/local/lib/*.so, /usr/local/lib/*.so.*
 
 
@@ -41,8 +40,8 @@ ARG APP_USER_ID="1000"
 ARG APP_GROUP_NAME="appgroup"
 ARG APP_GROUP_ID="1000"
 
-RUN apk add --no-cache bash jq libstdc++ util-linux git openssh-client curl aws-cli
-RUN python -m pip install -U pip setuptools wheel && \
+RUN apk add --no-cache bash jq libstdc++ util-linux git openssh-client curl aws-cli && \
+    python -m pip install -U pip setuptools wheel && \
     python -m pip install awscli-local terraform-local
 COPY --from=download /downloads/terraform /usr/local/bin/terraform
 COPY --from=download /downloads/hcl2json /usr/local/bin/hcl2json

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 .EXPORT_ALL_VARIABLES:
 TFCODING_VERSION ?= 0.0.9
-TERRAFORM_VERSION ?= 1.2.9
+TERRAFORM_VERSION ?= 1.6.6
 DOCKER_TAG ?= unfor19/tfcoding:$(TERRAFORM_VERSION)-$(TFCODING_VERSION)
 SRC_DIR_RELATIVE_PATH ?= examples/basic
+DOCKER_PLATFORM:=$(shell arch)
+OS_ARCH:=${DOCKER_PLATFORM}
 
 help:                ## Available make commands
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's~:~~' | sed -e 's~##~~'
@@ -10,8 +12,9 @@ help:                ## Available make commands
 usage: help         
 
 build:               ## Build tfcoding Docker image - default: terraform v0.13.6
-	docker build -t $(DOCKER_TAG) \
-		--build-arg TERRAFORM_VERSION=$(TERRAFORM_VERSION) .
+	docker build --platform linux/${DOCKER_PLATFORM} -t $(DOCKER_TAG) \
+		--build-arg TERRAFORM_VERSION=$(TERRAFORM_VERSION) \
+		--build-arg OS_ARCH=${OS_ARCH} .
 
 run:                 ## Run tfcoding in Docker
 	docker run --rm -it \

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,12 @@
 TFCODING_VERSION ?= 0.0.9
 TERRAFORM_VERSION ?= 1.6.6
 DOCKER_TAG ?= unfor19/tfcoding:$(TERRAFORM_VERSION)-$(TFCODING_VERSION)
+DOCKER_TAG_LATEST:=unfor19/tfcoding:latest
 SRC_DIR_RELATIVE_PATH ?= examples/basic
+
+ifndef DOCKER_PLATFORM
 DOCKER_PLATFORM:=$(shell arch)
+endif
 
 help:                ## Available make commands
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's~:~~' | sed -e 's~##~~'
@@ -11,7 +15,7 @@ help:                ## Available make commands
 usage: help         
 
 build:               ## Build tfcoding Docker image - default: terraform v0.13.6
-	docker build --platform linux/${DOCKER_PLATFORM} -t $(DOCKER_TAG) \
+	docker build --platform linux/${DOCKER_PLATFORM} -t $(DOCKER_TAG) -t ${DOCKER_TAG_LATEST} \
 		--build-arg TERRAFORM_VERSION=$(TERRAFORM_VERSION) \
 		--build-arg OS_ARCH=${OS_ARCH} .
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ TERRAFORM_VERSION ?= 1.6.6
 DOCKER_TAG ?= unfor19/tfcoding:$(TERRAFORM_VERSION)-$(TFCODING_VERSION)
 SRC_DIR_RELATIVE_PATH ?= examples/basic
 DOCKER_PLATFORM:=$(shell arch)
-OS_ARCH:=${DOCKER_PLATFORM}
 
 help:                ## Available make commands
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's~:~~' | sed -e 's~##~~'

--- a/README.md
+++ b/README.md
@@ -14,193 +14,94 @@ This is especially useful for learning about Expressions and Functions that you 
 
 - [Docker](https://docs.docker.com/get-docker/)
 - (Optional) [Docker Compose](https://docs.docker.com/compose/install/)
+- **Windows**
+
+  - [Windows Git Bash](https://gitforwindows.org/)
+  - [Chocolatey Windows Package Manager](https://chocolatey.org/install)
+
+    **IMPORTANT**: Open a PowerShell terminal as Administrator
+
+    ```powershell
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+    ```
+
+  - Install requirements
+
+    **IMPORTANT**: Open a PowerShell terminal as Administrator
+
+    ```bash
+    choco install -y make
+    ```
+
+- **macOS**:
+  - [Homebrew macOS Package Manager](https://brew.sh/)
+    ```bash
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    ```
+  - Install requirements
+    ```bash
+    brew install make
+    ```
 
 ## Quick Start
 
-```bash
-$ git clone https://github.com/unfor19/tfcoding.git
-$ cd tfcoding
-$ make run
+1. Clone this repo
+   ```bash
+   git clone https://github.com/unfor19/tfcoding.git
+   ```
+1. From now on your working direcotry should be `tfcoding`
+   ```
+   cd tfcoding
+   ```
+1. Render [examples/basic/tfcoding.tf](./examples/basic/tfcoding.tf) - Make changes in that file, like checking new [Terraform Expressions](https://developer.hashicorp.com/terraform/language/expressions)
+   ```
+   make run
+   ```
+1. Clean resources - Removes `tfcoding` container
+   ```bash
+   make clean
+   ```
 
-docker run --rm -it \
--v /home/meir/tfcoding/:/src/:ro \
-unfor19/tfcoding:latest-tf0.13.5 -r examples/basic --watching 
-[LOG] Thu Mar 25 00:23:59 UTC 2021 :: Terraform v0.13.6
-[LOG] Thu Mar 25 00:23:59 UTC 2021 :: Rendered for the first time
-{
-  "cidr_ab": "10.11",
-  "private_subnets": [
-    "10.11.0.0/24",
-    "10.11.1.0/24"
-  ]
-}
-[LOG] Thu Mar 25 00:23:59 UTC 2021 :: Watching for changes in /src/examples/basic/tfcoding.tf
-```
+## Getting Started
 
-### Modify the file [examples/basic/tfcoding.tf](./examples/basic/tfcoding.tf)
+This project uses [localstack](https://github.com/localstack/localstack), which means you can provision the [AWS core resources](https://github.com/localstack/localstack#overview), see [examples/mock-aws/](./examples/mock-aws/).
 
-This file contains the code that will be rendered and it must be stored in a relative directory to `$PWD`. Currently supports Variables and Local Values. To use Resources and Modules scroll down to Mock AWS.
+1. Clone this repo
+   ```bash
+   git clone https://github.com/unfor19/tfcoding.git
+   ```
+1. From now on your working direcotry should be `tfcoding`
+   ```
+   cd tfcoding
+   ```
+1. Render [examples/mock-aws/tfcoding.tf](./examples/mock-aws/tfcoding.tf) - Make changes in that file, like changing the CIDR of subnets
+   ```
+   make up-aws-localstack
+   ```
+1. Execute `terraform destroy` on changing `tfcoding.tf`, add the Local Value `terraform_destroy = true`. For example:
 
-```go
-variable "environment" {
-  default = "stg"
-}
+   ```go
+   // After "destroying" the infra, comment out this variable to execute `terraform apply`
+   locals {
+     terraform_destroy = true
+   }
+   ```
 
-variable "cidr_ab" {
-  type = map
-  default = {
-    "dev": "10.10"
-    "stg": "10.11"
-    "prd": "10.12"
-  }
-}
-
-locals {
-  cidr_ab = "${lookup(var.cidr_ab, var.environment)}"
-  private_subnets = [
-    "${local.cidr_ab}.0.0/24",
-    "${local.cidr_ab}.1.0/24",
-  ]
-}
-```
-
-## Docker Specific dir
-
-Mount the source code directory to `/src/` (read-only) and provide a relative path from `$PWD` to a directory that contains `tfcoding.tf`. The files that will be included in the rendering process are `tfcoding.tf` `*.tpl` and `*.json`.
-
-```bash
-$ git clone https://github.com/unfor19/tfcoding.git
-$ cd tfcoding
-$ make run SRC_DIR_RELATIVE_PATH=examples/basic
-```
-
-<details>
-
-<summary>Docker output - Expand/Collapse</summary>
-
-```bash
-[LOG] Sun Mar 21 22:28:24 UTC 2021 :: Terraform v0.13.5
-[LOG] Sun Mar 21 22:28:24 UTC 2021 :: Rendered for the first time
-{
-  "cidr_ab": "10.11",
-  "private_subnets": [
-    "10.11.0.0/24",
-    "10.11.1.0/24"
-  ]
-}
-[LOG] Sun Mar 21 22:28:24 UTC 2021 :: Watching for changes in /src/examples/basic/tfcoding.tf
-# Meanwhile ... Changed the map variable cidr_ab.stg from 10.11 to 10.17
-[LOG] Sun Mar 21 22:29:46 UTC 2021 :: Rendered
-{
-  "cidr_ab": "10.17",
-  "private_subnets": [
-    "10.17.0.0/24",
-    "10.17.1.0/24"
-  ]
-}
-
-# Hit CTRL+C to stop the app (container)
-# To see a more complicated example change basic to complex
-```
-
-</details>
-
-### Clean
-
-Stopping the container automatically removes it (`-rm`)
-
-## Docker Compose
-
-```bash
-$ git clone https://github.com/unfor19/tfcoding.git
-$ cd tfcoding
-$ make up
-```
-
-<details>
-
-<summary>docker-compose output - Expand/Collapse</summary>
-
-```bash
-Starting tfcoding ... done
-Attaching to tfcoding
-tfcoding    | [LOG] Mon Mar 22 00:00:35 UTC 2021 :: Terraform v0.13.5
-tfcoding    | [LOG] Mon Mar 22 00:00:35 UTC 2021 :: Rendered for the first time
-tfcoding    | {
-tfcoding    |   "cidr_ab": "10.11",
-tfcoding    |   "private_subnets": [
-tfcoding    |     "10.11.0.0/24",
-tfcoding    |     "10.11.1.0/24"
-tfcoding    |   ]
-tfcoding    | }
-tfcoding    | [LOG] Mon Mar 22 00:00:36 UTC 2021 :: Watching for changes in /src/examples/basic/tfcoding.tf
-# Meanwhile ... Changed the map variable cidr_ab.stg from 10.11 to 10.17
-tfcoding    | [LOG] Mon Mar 22 00:00:58 UTC 2021 :: Rendered
-tfcoding    | {
-tfcoding    |   "cidr_ab": "10.17",
-tfcoding    |   "private_subnets": [
-tfcoding    |     "10.17.0.0/24",
-tfcoding    |     "10.17.1.0/24"
-tfcoding    |   ]
-tfcoding    | }
-```
-
-</details>
-
-### Clean
-
-```bash
-$ make clean
-```
-
-## Mock AWS
-
-This feature relies on the open-source project [localstack](https://github.com/localstack/localstack), which means you can provision the [AWS core resources](https://github.com/localstack/localstack#overview), see [examples/mock-aws/](./examples/mock-aws/)
-
-
-### Run
-
-```bash
-$ git clone https://github.com/unfor19/tfcoding.git
-$ cd tfcoding
-$ make up-aws-localstack
-```
-
-### terraform destroy
-
-To execute `terraform destroy` on changing `tfcoding.tf`, add the Local Value `terraform_destroy = true`. For example:
-
-```go
-// After "destroying" the infra, remove this variable to execute `terraform apply`
-locals {
-  terraform_destroy = true
-}
-```
-
-### Clean
-
-```bash
-$ make clean-aws
-# OR
-$ make clean-localstack
-# OR
-$ make clean-aws-localstack
-```
-
-## Clean All
-
-Removes tfcoding, tfcoding-aws and localstack, including orphaned resources.
-
-```bash
-$ make clean-all
-```
+1. Clean resources - Removes `tfcoding` and `localstack` containers
+   ```bash
+   make clean-all
+   ```
 
 ## Help Menu
 
 ```bash
-$ make help
-# OR
-$ docker run --rm -it unfor19/tfcoding --help
+make help
+```
+
+With Docker:
+
+```bash
+docker run --rm -it unfor19/tfcoding --help
 ```
 
 <!-- replacer_start_helpmenu -->
@@ -218,7 +119,6 @@ Usage: bash entrypoint.sh -r basic/exmaples --watching -o private_subnets
 ```
 
 <!-- replacer_end_helpmenu -->
-
 
 ## Authors
 

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -9,12 +9,14 @@ volumes:
 services:
   tfcoding-aws:
     container_name: tfcoding-aws
+    platform: linux/${DOCKER_PLATFORM:-amd64}
     image: ${DOCKER_TAG:-unfor19/tfcoding:latest}
-    platform: ${DOCKER_PLATFORM:-linux/amd64}
     volumes:
       - ./:/src/:ro
-      - code_dir_tmp_aws:/tmp/
-
+      - ${HOME}/.aws:/home/appuser/.aws:ro
+    environment:
+      AWS_REGION: "us-east-1"
+      AWS_DEFAULT_REGION: "us-east-1"
     command:
       - "--src_dir_relative_path"
       - "${SRC_DIR_RELATIVE_PATH:-examples/mock-aws}"

--- a/docker-compose-localstack.yml
+++ b/docker-compose-localstack.yml
@@ -6,21 +6,17 @@ networks:
 services:
   localstack:
     container_name: localstack
-    image: localstack/localstack:${LOCALSTACK_VERSION:-1.1.0}
-    platform: ${DOCKER_PLATFORM:-linux/amd64}
+    image: localstack/localstack:${LOCALSTACK_VERSION:-3.0.2}
+    platform: linux/${DOCKER_PLATFORM:-amd64}
     ports:
       - "4566:4566"
       - "4571:4571"
-      - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
     environment:
-      - SERVICES=${SERVICES- }
-      - DEBUG=${DEBUG- }
-      - DATA_DIR=${DATA_DIR- }
-      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
-      - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER=${TMPDIR:-.localstack/}
+      DEBUG: "true"
+      LAMBDA_DOCKER_NETWORK: shared
+      MAIN_DOCKER_NETWORK: shared
+      DOCKER_HOST: unix:///var/run/docker.sock
     volumes:
-      - "${TMPDIR:-.localstack/}:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
     networks:
       - shared

--- a/examples/mock-aws/provider.tf
+++ b/examples/mock-aws/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 5.0.0"
     }
   }
 }
@@ -15,14 +15,18 @@ provider "aws" {
   access_key                  = "mock_access_key"
   region                      = "us-east-1"
   secret_key                  = "mock_secret_key"
+  s3_use_path_style           = true
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
+  insecure                    = true
 
   endpoints {
     apigateway     = "http://localstack:4566"
+    apigatewayv2   = "http://localstack:4566"
     cloudformation = "http://localstack:4566"
     cloudwatch     = "http://localstack:4566"
+    cloudwatchlogs = "http://localstack:4566"
     dynamodb       = "http://localstack:4566"
     ec2            = "http://localstack:4566"
     es             = "http://localstack:4566"
@@ -30,6 +34,7 @@ provider "aws" {
     iam            = "http://localstack:4566"
     kinesis        = "http://localstack:4566"
     lambda         = "http://localstack:4566"
+    rds            = "http://localstack:4566"
     route53        = "http://localstack:4566"
     redshift       = "http://localstack:4566"
     s3             = "http://localstack:4566"

--- a/examples/mock-aws/tfcoding.tf
+++ b/examples/mock-aws/tfcoding.tf
@@ -12,8 +12,8 @@ variable "cidr_ab" {
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
-  version = "~>3.14.4"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~>5.4.0"
 
   name = local.base_name
   cidr = "${local.cidr_ab}.0.0/16"
@@ -29,7 +29,7 @@ module "vpc" {
 locals {
   # terraform_destroy = true
   base_name = "myapp"
-  cidr_ab = lookup(var.cidr_ab, var.environment)
+  cidr_ab   = lookup(var.cidr_ab, var.environment)
   private_subnets = [
     "${local.cidr_ab}.0.0/24",
     "${local.cidr_ab}.1.0/24",


### PR DESCRIPTION
- Added support for running on macOS arm64
- Updated Terraform version `1.2.9` to `1.6.6`
- Updated LocalStack version from `1.1.0` to `3.0.2`
- Updated docs - easy copy-paste of code snippets
- Added more Terraform versions to the pipeline - `1.4.6`, `1.7.0-rc1`